### PR TITLE
fix(pocket-id): existingClaim functionality and `PUBLIC_UI_CONFIG_DISABLED` value

### DIFF
--- a/charts/pocket-id/templates/configmap.yaml
+++ b/charts/pocket-id/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
   UPLOAD_PATH: "data/uploads"
   KEYS_PATH: "data/keys"
   GEOLITE_DB_PATH: "data/GeoLite2-City.mmdb"
-  PUBLIC_UI_CONFIG_DISABLED: "{{ .Values.config.publicUI.useDefaults }}"
+  PUBLIC_UI_CONFIG_DISABLED: "{{ not .Values.config.publicUI.useDefaults }}"
   PUBLIC_APP_URL: "https://{{ $host }}"
   DB_PROVIDER: "{{ $provider }}"
   TZ: "{{ .Values.timeZone }}"

--- a/charts/pocket-id/templates/statefulset.yaml
+++ b/charts/pocket-id/templates/statefulset.yaml
@@ -47,8 +47,11 @@ spec:
           configMap:
             name: {{ include "pocket-id.backupConfig" . }}
       {{- end }}
-      {{- if not .Values.persistence.data.enabled }}
         - name: {{ include "pocket-id.pvcData" . }}
+      {{- if (and .Values.persistence.data.enabled (not (eq .Values.persistence.data.existingClaim ""))) }}
+          persistentVolumeClaim:
+            claimName: {{ include "pocket-id.pvcData" . }}
+      {{- else if not .Values.persistence.data.enabled }}
           emptyDir: {}
       {{- end }}
       {{- if .Values.backup.enabled }}
@@ -134,7 +137,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.persistence.data.enabled }}
+  {{- if (and .Values.persistence.data.enabled (eq .Values.persistence.data.existingClaim "")) }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "pocket-id.pvcData" . }}


### PR DESCRIPTION
## Description
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
This pull request fixes a couple issues with the `pocket-id` chart:
- The `persistence.data.existingClaim` setting was not being considered when templating volumes
- The `PUBLIC_UI_CONFIG_DISABLED` variable in the config map needs to be flipped to work as intended with `pocket-id`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the behavior of the UI configuration flag to accurately reflect the intended setting.
  - Improved volume mounting logic to ensure proper handling of persistent data, supporting both new and existing persistent volume claims and preventing configuration conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->