### PR TITLE
fix(pocket-id): one-time access email settings

### DIFF
--- a/charts/pocket-id/README.md
+++ b/charts/pocket-id/README.md
@@ -48,7 +48,8 @@ with their passkeys to your services.
 | config.publicUI.settings.app.emailsVerified | bool | `false` | Whether the user's email is pre-marked as verified for OIDC clients (typically used for testing) |
 | config.publicUI.settings.app.sessionDuration | int | `60` | Duration in minutes of a session before the user must sign in again |
 | config.publicUI.settings.email.loginNotificationEnabled | bool | `false` | Whether to send an email notification when a user logs in from a new device |
-| config.publicUI.settings.email.oneTimeAccessEnabled | bool | `false` | Whether to allow one-time access sign-ins via a link sent to the user's email    (note: this reduces security significantly, as anyone with email access can sign in) |
+| config.publicUI.settings.email.oneTimeAccessAsAdminEnabled | bool | `false` | Whether to allow admins to send one-time access sign-in links to the user's email |
+| config.publicUI.settings.email.oneTimeAccessAsUnauthenticatedEnabled | bool | `false` | Whether to allow unauthenticated users to request one-time access sign-in links sent to the user's email    (note: this reduces security significantly, as anyone with email access can sign in) |
 | config.publicUI.settings.ldap.attributes.group.adminGroup | string | `""` | LDAP attribute for the admin group (used to assign Admin privileges) |
 | config.publicUI.settings.ldap.attributes.group.member | string | `"member"` | LDAP attribute for querying group members |
 | config.publicUI.settings.ldap.attributes.group.name | string | `""` | LDAP attribute for the group's name |

--- a/charts/pocket-id/templates/configmap.yaml
+++ b/charts/pocket-id/templates/configmap.yaml
@@ -71,8 +71,11 @@ data:
   {{ if not (quote .Values.config.publicUI.settings.email.loginNotificationEnabled | empty) }}
   EMAIL_LOGIN_NOTIFICATION_ENABLED: "{{ .Values.config.publicUI.settings.email.loginNotificationEnabled }}"
   {{ end }}
-  {{ if not (quote .Values.config.publicUI.settings.email.oneTimeAccessEnabled | empty) }}
-  EMAIL_ONE_TIME_ACCESS_ENABLED: "{{ .Values.config.publicUI.settings.email.oneTimeAccessEnabled }}"
+  {{ if not (quote .Values.config.publicUI.settings.email.oneTimeAccessAsAdminEnabled | empty) }}
+  EMAIL_ONE_TIME_ACCESS_AS_ADMIN_ENABLED: "{{ .Values.config.publicUI.settings.email.oneTimeAccessAsAdminEnabled }}"
+  {{ end }}
+  {{ if not (quote .Values.config.publicUI.settings.email.oneTimeAccessAsUnauthenticatedEnabled | empty) }}
+  EMAIL_ONE_TIME_ACCESS_AS_UNAUTHENTICATED_ENABLED: "{{ .Values.config.publicUI.settings.email.oneTimeAccessAsUnauthenticatedEnabled }}"
   {{ end }}
   {{ if not (quote .Values.config.publicUI.settings.ldap.enabled | empty) }}
   LDAP_ENABLED: "{{ .Values.config.publicUI.settings.ldap.enabled }}"

--- a/charts/pocket-id/tests/configmap_test.yaml
+++ b/charts/pocket-id/tests/configmap_test.yaml
@@ -104,7 +104,8 @@ tests:
       config.publicUI.useDefaults: false
       config.publicUI.settings.email:
         loginNotificationEnabled: true
-        oneTimeAccessEnabled: false
+        oneTimeAccessAsAdminEnabled: false
+        oneTimeAccessAsUnauthenticatedEnabled: false
     asserts:
       - hasDocuments:
           count: 1
@@ -114,7 +115,8 @@ tests:
           path: data
           content:
             EMAIL_LOGIN_NOTIFICATION_ENABLED: "true"
-            EMAIL_ONE_TIME_ACCESS_ENABLED: "false"
+            EMAIL_ONE_TIME_ACCESS_AS_ADMIN_ENABLED: "false"
+            EMAIL_ONE_TIME_ACCESS_AS_UNAUTHENTICATED_ENABLED: "false"
 
   - it: Should create ConfigMap with publicUI values set (ldap)
     set:

--- a/charts/pocket-id/values.schema.json
+++ b/charts/pocket-id/values.schema.json
@@ -118,7 +118,10 @@
                     "loginNotificationEnabled": {
                       "type": "boolean"
                     },
-                    "oneTimeAccessEnabled": {
+                    "oneTimeAccessAsAdminEnabled": {
+                      "type": "boolean"
+                    },
+                    "oneTimeAccessAsUnauthenticatedEnabled": {
                       "type": "boolean"
                     }
                   },

--- a/charts/pocket-id/values.yaml
+++ b/charts/pocket-id/values.yaml
@@ -180,9 +180,12 @@ config:
         # -- Whether to send an email notification when a user logs in from a new device
         loginNotificationEnabled: false
 
-        # -- Whether to allow one-time access sign-ins via a link sent to the user's email
+        # -- Whether to allow admins to send one-time access sign-in links to the user's email
+        oneTimeAccessAsAdminEnabled: false
+
+        # -- Whether to allow unauthenticated users to request one-time access sign-in links sent to the user's email
         #    (note: this reduces security significantly, as anyone with email access can sign in)
-        oneTimeAccessEnabled: false
+        oneTimeAccessAsUnauthenticatedEnabled: false
 
       ldap:
         # -- Whether to enable LDAP authentication


### PR DESCRIPTION

## Description
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
The naming was slightly wrong here, and only attempted to configure one of the two one-time access email settings.
