### PR TITLE
fix(pocket-id): mount paths

### DIFF
--- a/charts/pocket-id/templates/backup-configmap.yaml
+++ b/charts/pocket-id/templates/backup-configmap.yaml
@@ -20,7 +20,7 @@ data:
     secret-access-key: "$SECRET_KEY"
     {{- end }}
     dbs:
-      - path: /app/backend/data/pocket-id.db
+      - path: /app/data/pocket-id.db
         {{- if .Values.backup.monitorInterval }}
         monitor-interval: {{ .Values.backup.monitorInterval }}
         {{- end }}

--- a/charts/pocket-id/templates/statefulset.yaml
+++ b/charts/pocket-id/templates/statefulset.yaml
@@ -66,12 +66,12 @@ spec:
             - restore
             - -if-replica-exists=true
             - -config=/mnt/config/litestream.yaml
-            - /app/backend/data/pocket-id.db
+            - /app/data/pocket-id.db
           resources:
             {{- toYaml .Values.pocketID.resources | nindent 12 }}
           volumeMounts:
             - name: {{ include "pocket-id.pvcData" . }}
-              mountPath: /app/backend/data
+              mountPath: /app/data
             - name: config
               mountPath: /mnt/config
           envFrom:
@@ -101,7 +101,7 @@ spec:
             {{- toYaml .Values.pocketID.resources | nindent 12 }}
           volumeMounts:
             - name: {{ include "pocket-id.pvcData" . }}
-              mountPath: /app/backend/data
+              mountPath: /app/data
           envFrom:
             - secretRef:
                 name: {{ include "pocket-id.secret" . }}
@@ -120,7 +120,7 @@ spec:
             {{- toYaml .Values.pocketID.resources | nindent 12 }}
           volumeMounts:
             - name: {{ include "pocket-id.pvcData" . }}
-              mountPath: /app/backend/data
+              mountPath: /app/data
             - name: config
               mountPath: /mnt/config
           ports:

--- a/charts/pocket-id/tests/statefulset_test.yaml
+++ b/charts/pocket-id/tests/statefulset_test.yaml
@@ -55,7 +55,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: test-claim
-            mountPath: /app/backend/data
+            mountPath: /app/data
       - notExists:
           path: spec.volumeClaimTemplates
 
@@ -99,7 +99,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: RELEASE-NAME-pocket-id-data
-            mountPath: /app/backend/data
+            mountPath: /app/data
 
   - it: Should include config volume when backup is enabled
     set:


### PR DESCRIPTION
### **User description**
## Description
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
The pocket-id chart is currently using the pre-1.0.0 mount path. This is [now `/app/data`](https://pocket-id.org/docs/setup/migrate-to-v1/) after 1.0.0.


___

### **PR Type**
Bug fix


___

### **Description**
• Update mount paths from `/app/backend/data` to `/app/data`
• Fix compatibility with pocket-id v1.0.0+ path changes
• Update backup configuration and test files


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backup-configmap.yaml</strong><dd><code>Update backup database path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/templates/backup-configmap.yaml

• Updated database path in litestream configuration from <br><code>/app/backend/data/pocket-id.db</code> to <code>/app/data/pocket-id.db</code>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/153/files#diff-feaf696dbe1ce0f4a458270e454b4b0fdb09eec42b002a42345f0a2215b0ad82">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Fix container mount paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/templates/statefulset.yaml

• Changed mount path from <code>/app/backend/data</code> to <code>/app/data</code> in init <br>container<br> • Updated mount path in main pocket-id container<br> • Fixed <br>mount path in backup sidecar container<br> • Updated restore command <br>database path


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/153/files#diff-f56b914349e28742306d76df42814fca5551667b71728b172ba02b91bbdfef1d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset_test.yaml</strong><dd><code>Update test mount path expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/tests/statefulset_test.yaml

• Updated test assertions to expect <code>/app/data</code> mount path instead of <br><code>/app/backend/data</code>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/153/files#diff-af83423376da9fe64d6bad2736fabd4b066917b317de04cd75332b3f4797a411">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>