### PR TITLE
feat: allow postgresql:// as protocol in connectionString

### DIFF
--- a/charts/pocket-id/Chart.yaml
+++ b/charts/pocket-id/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   pocket-id is a simple and easy-to-use OIDC provider that allows users to authenticate
   with their passkeys to your services.
 home: https://pocket-id.org
-version: 1.1.5
+version: 1.2.0
 appVersion: "v1.3.1"
 sources:
   - https://github.com/pocket-id/pocket-id

--- a/charts/pocket-id/templates/secret.yaml
+++ b/charts/pocket-id/templates/secret.yaml
@@ -2,9 +2,10 @@
 {{- $provider := default "sqlite" .Values.database.provider }}
 {{- $dbConnection := .Values.database.connectionString | required ".Values.database.connectionString is required." }}
 {{- if eq $provider "postgres" }}
-  {{- if not (hasPrefix "postgres://" $dbConnection) }}
-    {{- fail (printf "Invalid database connectionString: %s. .Values.database.connectionString must start with 'postgres://' when .Values.database.provider is 'postgres'." $dbConnection) }}
+  {{- if not (or (hasPrefix "postgres://" $dbConnection) (hasPrefix "postgresql://" $dbConnection)) }}
+    {{- fail (printf "Invalid database connectionString: %s. .Values.database.connectionString must start with 'postgres://' or 'postgresql://' when .Values.database.provider is 'postgres'." $dbConnection) }}
   {{- end }}
+{{- end }}
 {{- else if eq $provider "sqlite" }}
   {{- if not (hasPrefix "file:data/pocket-id.db" $dbConnection) }}
     {{- fail (printf "Invalid database connectionString: %s. .Values.database.connectionString must start with 'file:data/pocket-id.db' when .Values.database.provider is 'sqlite'." $dbConnection) }}

--- a/charts/pocket-id/values.yaml
+++ b/charts/pocket-id/values.yaml
@@ -20,7 +20,7 @@ database:
 
   # -- Connection string for the database.
   #    - For sqlite: file:data/pocket-id.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate
-  #    - For postgres: postgres://user:password@host:port/dbname
+  #    - For postgres: postgres(ql)://user:password@host:port/dbname
   connectionString: "file:data/pocket-id.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate"
 
 updateStrategy:
@@ -39,7 +39,8 @@ pocketID:
     # -- Image pull policy.
     pullPolicy: IfNotPresent
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -51,7 +52,8 @@ pocketID:
     #   cpu: 100m
     #   memory: 128Mi
 
-  securityContext: {}
+  securityContext:
+    {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -68,7 +70,8 @@ backup:
     # -- Image pull policy.
     pullPolicy: IfNotPresent
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -80,7 +83,8 @@ backup:
     #   cpu: 100m
     #   memory: 128Mi
 
-  securityContext: {}
+  securityContext:
+    {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -119,7 +123,8 @@ backup:
     # -- Primary S3 secret key.
     secretKey: ""
 
-    replicas: []
+    replicas:
+      []
       # - accessKey: ""
       #   secretKey: ""
       #   region: ""
@@ -300,7 +305,8 @@ ingress:
   # -- Ingress class name.
   className: ""
   # -- Annotations to add to the ingress.
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # -- Ingress host configuration.
@@ -319,7 +325,8 @@ podAnnotations: {}
 # -- Labels to be added to the pods.
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 # -- Node selector for the pods.
@@ -329,7 +336,8 @@ nodeSelector: {}
 tolerations: []
 
 # -- Affinity settings for the pods.
-affinity: {}
+affinity:
+  {}
   # nodeAffinity:
   #   requiredDuringSchedulingIgnoredDuringExecution:
   #     nodeSelectorTerms:


### PR DESCRIPTION
### **User description**
## Description
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
When using CloudnativePG in combination with FluxCD, eg:

```yaml
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: pocket-id
  namespace: auth
spec:
  interval: 10m
  chart:
    spec:
      chart: pocket-id
      version: 1.1.5
      sourceRef:
        kind: HelmRepository
        name: anza-labs
        namespace: auth
      interval: 10m
  values:
    database:
      provider: postgres
  valuesFrom:
    - kind: Secret
      name: pocket-id-app
      targetPath: database.connectionString
      valuesKey: uri
```

You receive the following error:
```
Helm install failed for release auth/pocket-id with chart pocket-id@1.1.5: execution error at (pocket-id/templates/secret.yaml:6:8): Invalid database connectionString
: postgresql://app:ZOE....5skyKzXG5@pocket-id-rw.auth:5432/app. .Values.database.connectionString must start with 'postgres://' when .Values.database.provider is 'postgres'.
```

This should fix this error.


___

### **PR Type**
Enhancement


___

### **Description**
• Allow `postgresql://` protocol in database connection strings
• Update validation logic to accept both `postgres://` and `postgresql://` schemes
• Bump Helm chart version to 1.2.0
• Update documentation to clarify supported connection string formats


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Bump chart version to 1.2.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/Chart.yaml

• Bump chart version from 1.1.5 to 1.2.0


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/159/files#diff-11398669dfb82674d6b9c09b7c4aec42bb3add3f824959751d102e9a21a0c04e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.yaml</strong><dd><code>Support postgresql:// connection string validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/templates/secret.yaml

• Update validation to accept both <code>postgres://</code> and <code>postgresql://</code> <br>prefixes<br> • Modify error message to reflect both supported schemes<br> • <br>Fix template structure with proper <code>{{- end }}</code> placement


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/159/files#diff-284e684e9386380733190f597a7794e2f9127bebeca46e39741358f93c9817ae">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update documentation and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/values.yaml

• Update comment to show <code>postgres(ql)://</code> format support<br> • Apply <br>formatting changes to YAML structure for consistency


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/159/files#diff-c4de17c248195b1df176f205205ce13c8bb65104cf251db2ca5699755691211c">+17/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>