### PR TITLE
feat(templates): add more probe configurations

### DIFF
--- a/charts/lubelogger/README.md
+++ b/charts/lubelogger/README.md
@@ -120,6 +120,7 @@ LubeLogger is a web-based vehicle maintenance and fuel mileage tracker
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| startupProbe.httpGet | object | `{"path":"/","port":"http"}` | Startup probe configuration. |
 | tolerations | list | `[]` | Tolerations for the pods. |
 | updateStrategy.rollingUpdate.maxUnavailable | string | `"100%"` |  |
 | updateStrategy.rollingUpdate.partition | int | `0` |  |

--- a/charts/lubelogger/templates/statefulset.yaml
+++ b/charts/lubelogger/templates/statefulset.yaml
@@ -105,6 +105,8 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/lubelogger/values.schema.json
+++ b/charts/lubelogger/values.schema.json
@@ -436,6 +436,22 @@
         }
       }
     },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "tolerations": {
       "type": "array"
     },

--- a/charts/lubelogger/values.yaml
+++ b/charts/lubelogger/values.yaml
@@ -277,6 +277,12 @@ readinessProbe:
     path: /
     port: http
 
+startupProbe:
+  # -- Startup probe configuration.
+  httpGet:
+    path: /
+    port: http
+
 autoscaling:
   # -- Specifies whether autoscaling is enabled.
   enabled: false

--- a/charts/pocket-id/README.md
+++ b/charts/pocket-id/README.md
@@ -94,6 +94,7 @@ with their passkeys to your services.
 | ingress.paths[0].path | string | `"/"` |  |
 | ingress.paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` | List of TLS configurations for the ingress. |
+| livenessProbe.httpGet | object | `{"path":"/healthz","port":"http"}` | Liveness probe configuration. |
 | maxmindLicenseKey | string | `""` | MaxMind license key used to download the GeoLite2 database. Leave blank to disable download. |
 | nameOverride | string | `""` | Override for the name. |
 | nodeSelector | object | `{}` | Node selector for the pods. |
@@ -111,6 +112,7 @@ with their passkeys to your services.
 | podAnnotations | object | `{}` | Annotations to be added to the pods. |
 | podLabels | object | `{}` | Labels to be added to the pods. |
 | podSecurityContext | object | `{}` |  |
+| readinessProbe.httpGet | object | `{"path":"/healthz","port":"http"}` | Readiness probe configuration. |
 | replicaCount | int | `1` | Number of replicas for the stateful set. |
 | secret.create | bool | `true` | Specifies whether a secret should be created. |
 | secret.name | string | `""` | Specifies name of a secret used to configure the pocket-id. If not filled, uses full name. |
@@ -121,6 +123,7 @@ with their passkeys to your services.
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| startupProbe.httpGet | object | `{"path":"/healthz","port":"http"}` | Startup probe configuration. |
 | timeZone | string | `"Etc/UTC"` | Specifies the time zone to be used by the application. Use a valid IANA time zone string (e.g., "Etc/UTC", "America/New_York"). |
 | tolerations | list | `[]` | Tolerations for the pods. |
 | updateStrategy.rollingUpdate.maxUnavailable | string | `"100%"` |  |

--- a/charts/pocket-id/templates/statefulset.yaml
+++ b/charts/pocket-id/templates/statefulset.yaml
@@ -89,14 +89,11 @@ spec:
               containerPort: 1411
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            initialDelaySeconds: 60
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.pocketID.resources | nindent 12 }}
           volumeMounts:

--- a/charts/pocket-id/values.schema.json
+++ b/charts/pocket-id/values.schema.json
@@ -319,6 +319,22 @@
         }
       }
     },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "maxmindLicenseKey": {
       "type": "string"
     },
@@ -390,6 +406,22 @@
     "podSecurityContext": {
       "type": "object"
     },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "replicaCount": {
       "type": "integer"
     },
@@ -432,6 +464,22 @@
         },
         "name": {
           "type": "string"
+        }
+      }
+    },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/charts/pocket-id/values.yaml
+++ b/charts/pocket-id/values.yaml
@@ -293,6 +293,24 @@ service:
   # -- Annotations to add to the service.
   annotations: {}
 
+livenessProbe:
+  # -- Liveness probe configuration.
+  httpGet:
+    path: /healthz
+    port: http
+
+readinessProbe:
+  # -- Readiness probe configuration.
+  httpGet:
+    path: /healthz
+    port: http
+
+startupProbe:
+  # -- Startup probe configuration.
+  httpGet:
+    path: /healthz
+    port: http
+
 serviceAccount:
   # -- Specifies whether a service account should be created.
   create: true


### PR DESCRIPTION
### **User description**
<!--
Usage: `Resolves #<issue number>`, or `Resolves <link to the issue>`.
If PR is about `failing-tests`, please post the related tests in a comment and do not use `Resolves`
-->
Resolves #180


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable probe settings for Kubernetes health checks

- Replace hardcoded probe values with template-based configuration

- Enable startup probe support for both applications

- Update documentation and schema for new probe options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Probes"] --> B["Template-based Probes"]
  B --> C["Configurable Health Checks"]
  C --> D["Enhanced Kubernetes Support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document startup probe configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/lubelogger/README.md

- Add documentation for `startupProbe.httpGet` configuration option


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-80be17549ec2d159d8d4160bf4a07908119e2c12f6b6a82d9cb983bdcd98ec3b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document all probe configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/README.md

<ul><li>Document <code>livenessProbe.httpGet</code>, <code>readinessProbe.httpGet</code>, and <br><code>startupProbe.httpGet</code> configurations<br> <li> All probes use <code>/healthz</code> endpoint by default</ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-1853e1f4586a884a4c7749dd2bbdcc3b4c03c761c2d2b9c6f12cf46cff431a76">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Add startup probe to statefulset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/lubelogger/templates/statefulset.yaml

- Add startup probe configuration using template values


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-06f1881adbce218548550bebdbe5ab4779fe9279d573e8c1f9587bd40b8f7f35">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Replace hardcoded probes with templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/templates/statefulset.yaml

<ul><li>Replace hardcoded probe configurations with template values<br> <li> Remove <code>initialDelaySeconds</code> from readiness probe<br> <li> Add startup probe using template configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-f56b914349e28742306d76df42814fca5551667b71728b172ba02b91bbdfef1d">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.schema.json</strong><dd><code>Add startup probe schema validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/lubelogger/values.schema.json

<ul><li>Add JSON schema definition for <code>startupProbe</code> object<br> <li> Define <code>httpGet</code> properties with <code>path</code> and <code>port</code> fields</ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-a8d2166308dc1d3499f21dab9deb585c43f26ee3de3a9fea2764447c23c4ef30">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add startup probe default values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/lubelogger/values.yaml

<ul><li>Add <code>startupProbe</code> configuration with default HTTP health check<br> <li> Set default path to <code>/</code> and port to <code>http</code></ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-182876ef025d0b91ae223601813fbaae553ebdf4bd1792c6a80512b52878f016">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.schema.json</strong><dd><code>Add probe schema validations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/values.schema.json

<ul><li>Add JSON schema definitions for <code>livenessProbe</code>, <code>readinessProbe</code>, and <br><code>startupProbe</code><br> <li> Define <code>httpGet</code> properties for all probe types</ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-e7d1ff861e253e63ba85e83826765266998e7711bcf1fcf68f3de01a351f00f5">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add probe default configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/values.yaml

<ul><li>Add <code>livenessProbe</code>, <code>readinessProbe</code>, and <code>startupProbe</code> configurations<br> <li> Set all probes to use <code>/healthz</code> endpoint on <code>http</code> port</ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/189/files#diff-c4de17c248195b1df176f205205ce13c8bb65104cf251db2ca5699755691211c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

