### PR TITLE
feat(pocket-id): set only selector labels on volumes

### DIFF
--- a/charts/pocket-id/templates/statefulset.yaml
+++ b/charts/pocket-id/templates/statefulset.yaml
@@ -145,7 +145,7 @@ spec:
     - metadata:
         name: {{ include "pocket-id.pvcData" . }}
         labels:
-          {{- include "pocket-id.labels" . | nindent 10 }}
+          {{- include "pocket-id.selectorLabels" . | nindent 10 }}
         {{- if .Values.persistence.data.annotations }}
         annotations:
           {{- toYaml .Values.persistence.data.annotations | nindent 10 }}


### PR DESCRIPTION
### **User description**
Resolves #255


___

### **PR Type**
Enhancement


___

### **Description**
- Replace full labels with selector labels on PVC metadata

- Ensures only necessary selector labels are applied to volumes

- Aligns with Kubernetes best practices for volume claim templates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PVC["PVC Metadata Labels"]
  Full["Full Labels<br/>pocket-id.labels"]
  Selector["Selector Labels<br/>pocket-id.selectorLabels"]
  PVC -->|Before| Full
  PVC -->|After| Selector
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Replace full labels with selector labels on PVC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/pocket-id/templates/statefulset.yaml

<ul><li>Changed volumeClaimTemplates metadata labels from <code>pocket-id.labels</code> to <br><code>pocket-id.selectorLabels</code><br> <li> Reduces label overhead by applying only selector labels to PVC <br>metadata<br> <li> Maintains consistency with Kubernetes volume claim template best <br>practices</ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/257/files#diff-f56b914349e28742306d76df42814fca5551667b71728b172ba02b91bbdfef1d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

