### PR TITLE
feat(lubelogger): set only selector labels on volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The following charts are deprecated and should not be used for new deployments:
 
 | Name | Version | App Version |
 |------|---------|-------------|
-| [hosted-control-plane](deprecated/hosted-control-plane) | `0.3.0` |
-| [kamaji](deprecated/kamaji) | `0.1.11` |
-| [kube-storage-version-migrator](deprecated/kube-storage-version-migrator) | `0.1.1` |
-| [omada-controller](deprecated/omada-controller) | `0.3.1` |
-| [podvm](deprecated/podvm) | `0.0.0-alpha.10` |
-| [scribe](deprecated/scribe) | `0.3.7` |
+| [hosted-control-plane](deprecated/hosted-control-plane) | `0.3.0` | `v1.33.1` |
+| [kamaji](deprecated/kamaji) | `0.1.11` | `edge-25.4.1` |
+| [kube-storage-version-migrator](deprecated/kube-storage-version-migrator) | `0.1.1` | `v0.0.5` |
+| [omada-controller](deprecated/omada-controller) | `0.3.1` | `5.15.24.17` |
+| [podvm](deprecated/podvm) | `0.0.0-alpha.10` | `v1.12.0` |
+| [scribe](deprecated/scribe) | `0.3.7` | `v0.3.0` |

--- a/README.md.gotpl
+++ b/README.md.gotpl
@@ -29,6 +29,6 @@ The following charts are deprecated and should not be used for new deployments:
 |------|---------|-------------|
 {{- range . }}
 {{- if .Deprecated }}
-| [{{ .Name }}](deprecated/{{ .Name }}) | `{{ .Version }}` |
+| [{{ .Name }}](deprecated/{{ .Name }}) | `{{ .Version }}` | `{{ .AppVersion }}` |
 {{- end }}
 {{- end }}

--- a/charts/lubelogger/templates/statefulset.yaml
+++ b/charts/lubelogger/templates/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
     - metadata:
         name: {{ include "lubelog.pvcData" . }}
         labels:
-          {{- include "lubelog.labels" . | nindent 10 }}
+          {{- include "lubelog.selectorLabels" . | nindent 10 }}
         annotations:
           helm.sh/resource-policy: "keep"
         {{- if .Values.persistence.data.annotations }}


### PR DESCRIPTION
### **User description**
Resolves #255


___

### **PR Type**
Enhancement


___

### **Description**
- Replace full labels with selector labels on volumeClaimTemplates

- Ensures only necessary selector labels are set on PVC metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  VCT["volumeClaimTemplates metadata"] -- "replace labels" --> SL["selector labels only"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Replace full labels with selector labels on PVC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/lubelogger/templates/statefulset.yaml

<ul><li>Changed volumeClaimTemplates metadata labels from <code>lubelog.labels</code> to <br><code>lubelog.selectorLabels</code><br> <li> Ensures PVC labels are limited to selector labels only, reducing <br>unnecessary metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/anza-labs/charts/pull/258/files#diff-06f1881adbce218548550bebdbe5ab4779fe9279d573e8c1f9587bd40b8f7f35">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

