### PR TITLE
feat(pocket-id): add trust proxy configuration options

### DIFF
--- a/charts/pocket-id/README.md
+++ b/charts/pocket-id/README.md
@@ -153,6 +153,8 @@ with their passkeys to your services.
 | staticApiKey | string | `""` | Static API key that grants admin access. Creates an admin account called "Static API User". |
 | timeZone | string | `"Etc/UTC"` | Specifies the time zone to be used by the application. Use a valid IANA time zone string (e.g., "Etc/UTC", "America/New_York"). |
 | tolerations | list | `[]` | Tolerations for the pods. |
+| trustProxy | bool | `true` | Trust proxy headers (e.g. X-Forwarded-For) from the reverse proxy in front of pocket-id. |
+| trustedPlatform | string | `""` | Specifies the platform trusted by the application. Supported values: - `X-Appengine-Remote-Addr` - For Google App Engine - `CF-Connecting-IP` - For Cloudflare - `Fly-Client-IP` - For Fly.io - Any custom header name that your reverse proxy uses to pass the client's real IP. |
 | updateStrategy.rollingUpdate.maxUnavailable | string | `"100%"` |  |
 | updateStrategy.rollingUpdate.partition | int | `0` |  |
 | updateStrategy.type | string | `"RollingUpdate"` | The deployment strategy to use to replace existing pods with new ones. Options: "RollingUpdate" or "OnDelete". |

--- a/charts/pocket-id/templates/configmap.yaml
+++ b/charts/pocket-id/templates/configmap.yaml
@@ -15,7 +15,14 @@ metadata:
 data:
   HOST: "0.0.0.0"
   PORT: "1411"
+  {{ if not (quote .Values.trustProxy | empty) }}
+  TRUST_PROXY: "{{ .Values.trustProxy }}"
+  {{ else }}
   TRUST_PROXY: "true"
+  {{ end }}
+  {{ if .Values.trustedPlatform }}
+  TRUSTED_PLATFORM: "{{ .Values.trustedPlatform }}"
+  {{ end }}
   VERSION_CHECK_DISABLED: "true"
   ANALYTICS_DISABLED: "{{ .Values.analyticsDisabled | default false }}"
   GEOLITE_DB_PATH: "data/GeoLite2-City.mmdb"

--- a/charts/pocket-id/tests/configmap_test.yaml
+++ b/charts/pocket-id/tests/configmap_test.yaml
@@ -30,6 +30,7 @@ tests:
       - isSubset:
           path: data
           content:
+            TRUST_PROXY: "true"
             ANALYTICS_DISABLED: "false"
             VERSION_CHECK_DISABLED: "true"
             GEOLITE_DB_URL: "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz"
@@ -37,11 +38,17 @@ tests:
             TZ: "Etc/UTC"
             TRACING_ENABLED: "false"
             METRICS_ENABLED: "false"
+      - isNotSubset:
+          path: data
+          content:
+            TRUSTED_PLATFORM: ""
 
   - it: Should create ConfigMap with overrides
     set:
       ingress.host: example.com
       timeZone: Europe/Berlin
+      trustProxy: false
+      trustedPlatform: CF-Connecting-IP
       geoliteDatabaseURL: https://example.com/db.tar.gz
       analyticsDisabled: true
     asserts:
@@ -50,6 +57,8 @@ tests:
       - isSubset:
           path: data
           content:
+            TRUST_PROXY: "false"
+            TRUSTED_PLATFORM: "CF-Connecting-IP"
             ANALYTICS_DISABLED: "true"
             VERSION_CHECK_DISABLED: "true"
             GEOLITE_DB_URL: "https://example.com/db.tar.gz"

--- a/charts/pocket-id/values.schema.json
+++ b/charts/pocket-id/values.schema.json
@@ -587,6 +587,12 @@
     "tolerations": {
       "type": "array"
     },
+    "trustProxy": {
+      "type": "boolean"
+    },
+    "trustedPlatform": {
+      "type": "string"
+    },
     "updateStrategy": {
       "type": "object",
       "properties": {

--- a/charts/pocket-id/values.yaml
+++ b/charts/pocket-id/values.yaml
@@ -18,6 +18,17 @@ maxmindLicenseKey: ""
 # -- Host where you will access the app.
 host: ""
 
+# -- Trust proxy headers (e.g. X-Forwarded-For) from the reverse proxy in front of pocket-id.
+trustProxy: true
+
+# -- Specifies the platform trusted by the application.
+# Supported values:
+# - `X-Appengine-Remote-Addr` - For Google App Engine
+# - `CF-Connecting-IP` - For Cloudflare
+# - `Fly-Client-IP` - For Fly.io
+# - Any custom header name that your reverse proxy uses to pass the client's real IP.
+trustedPlatform: ""
+
 # -- Encryption key used to encrypt sensitive data.
 # Required: Generate with `openssl rand -base64 32`
 encryptionKey: ""


### PR DESCRIPTION
## Description
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
Add trustProxy and trustedPlatform configuration options to allow users to
configure how pocket-id handles reverse proxy headers. This enables proper
client IP detection when pocket-id is deployed behind a reverse proxy like
Cloudflare, Google App Engine, or Fly.io.

<!--
Usage: `Resolves #<issue number>`, or `Resolves <link to the issue>`.
If PR is about `failing-tests`, please post the related tests in a comment and do not use `Resolves`
-->
Resolves #370 
