### PR TITLE
fix(glauth): mount config as TOML file

### DIFF
--- a/charts/glauth/templates/_helpers.tpl
+++ b/charts/glauth/templates/_helpers.tpl
@@ -64,3 +64,28 @@ Create secret name used for configuring glauth.
 {{- define "glauth.secret" -}}
     {{- default (printf "%s" (include "glauth.fullname" .)) .Values.secret.name }}
 {{- end }}
+
+{{/*
+Recursively walk a structure and convert float64 -> int64.
+*/}}
+{{- define "convertFloatsToInts" -}}
+    {{- $v := . -}}
+{{- if kindIs "map" $v -}}
+  {{- range $k, $val := $v -}}
+    {{- if kindIs "float64" $val -}}
+      {{- $_ := set $v $k (int64 $val) -}}
+    {{- else if or (kindIs "map" $val) (kindIs "slice" $val) -}}
+      {{- include "convertFloatsToInts" $val -}}
+    {{- end -}}
+  {{- end -}}
+
+{{- else if kindIs "slice" $v -}}
+  {{- range $i, $val := $v -}}
+    {{- if kindIs "float64" $val -}}
+      {{- $_ := set $v $i (int64 $val) -}}
+    {{- else if or (kindIs "map" $val) (kindIs "slice" $val) -}}
+      {{- include "convertFloatsToInts" $val -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/glauth/templates/deployment.yaml
+++ b/charts/glauth/templates/deployment.yaml
@@ -34,12 +34,17 @@ spec:
       serviceAccountName: {{ include "glauth.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "glauth.secret" . }}
       containers:
         - name: glauth
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/app/glauth", "--config", "/app/config/config.cfg"]
           ports:
             {{- if .Values.secret.value.api.enabled }}
             - name: api
@@ -56,11 +61,12 @@ spec:
               containerPort: {{ index ( splitList ":" .Values.secret.value.ldaps.listen ) 1 }}
               protocol: TCP
             {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          envFrom:
-            - secretRef:
-                name: {{ include "glauth.secret" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/glauth/templates/secret.yaml
+++ b/charts/glauth/templates/secret.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.secret.create -}}
+{{- $cfg := deepCopy .Values.secret.value -}}
+{{- include "convertFloatsToInts" $cfg -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,10 +10,6 @@ metadata:
     {{- include "glauth.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  glauth.toml: |
-    {{- if kindIs "string" .Values.secret.value }}
-    {{- .Values.secret.value | nindent 4 }}
-    {{- else }}
-    {{- .Values.secret.value | toToml | nindent 4 }}
-    {{- end }}
+  config.cfg: |
+    {{- $cfg | toToml | nindent 4 }}
 {{- end }}

--- a/e2e/glauth/config/chainsaw-test.yaml
+++ b/e2e/glauth/config/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     - name: arguments
       value: |
-        --set-json=secret.value.users=[{"name":"serviceuser","mail":"serviceuser@example.com","uidnumber":5003,"primarygroup":5502,"passsha256":"652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0"}]
+        --set-json=secret.value.users=[{"name":"serviceuser","mail":"serviceuser@example.com","uidnumber":5003,"primarygroup":5502,"passsha256":"652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0","capabilities":[{"action":"search","object":"*"}]}]
         --set-json=secret.value.groups=[{"name":"svcaccts","gidnumber":5502}]
 
   steps:

--- a/e2e/registry/_lib/test-pull.step.yaml
+++ b/e2e/registry/_lib/test-pull.step.yaml
@@ -44,7 +44,8 @@ spec:
                         crane --verbose \
                           copy \
                           --insecure=${INSECURE} \
-                          ghcr.io/anza-labs/library/distroless/static:latest \
+                          --platform linux/amd64 \
+                          registry.k8s.io/pause:3.10 \
                           "${NAMESPACE}-registry.${NAMESPACE}:5000/pull/test:latest"
 
                         crane --verbose \

--- a/e2e/registry/_lib/test-push.step.yaml
+++ b/e2e/registry/_lib/test-push.step.yaml
@@ -44,7 +44,8 @@ spec:
                         crane --verbose \
                           pull \
                           --insecure=${INSECURE} \
-                          ghcr.io/anza-labs/library/distroless/static:latest \
+                          --platform linux/amd64 \
+                          registry.k8s.io/pause:3.10 \
                           /tmp/test.tar
 
                         crane --verbose \


### PR DESCRIPTION
glauth expects a config file, not env vars. Switch the secret from
envFrom keys to a `config.cfg` TOML mounted at /app/config, and
invoke glauth with `--config`.

helm `--set-json` renders numeric fields as float64, which breaks
`uidnumber`/`gidnumber`/`primarygroup` when serialized via `toToml`.
Add a `convertFloatsToInts` helper that walks the parsed value tree
and coerces floats to int64 before TOML marshaling.

Also require explicit `capabilities` on the e2e serviceuser - glauth
v2.5.0 returns "Insufficient access (50)" otherwise.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek.98@gmail.com>
