### PR TITLE
test(pocket-id): add LDAP sync e2e against glauth

### DIFF
--- a/charts/pocket-id/templates/configmap.yaml
+++ b/charts/pocket-id/templates/configmap.yaml
@@ -129,9 +129,6 @@ data:
   {{ if not (quote .Values.config.ui.settings.ldap.bindDN | empty) }}
   LDAP_BIND_DN: "{{ .Values.config.ui.settings.ldap.bindDN }}"
   {{ end }}
-  {{ if not (quote .Values.config.ui.settings.ldap.bindPassword | empty) }}
-  LDAP_BIND_PASSWORD: "{{ .Values.config.ui.settings.ldap.bindPassword }}"
-  {{ end }}
   {{ if not (quote .Values.config.ui.settings.ldap.base | empty) }}
   LDAP_BASE: "{{ .Values.config.ui.settings.ldap.base }}"
   {{ end }}

--- a/charts/pocket-id/templates/secret.yaml
+++ b/charts/pocket-id/templates/secret.yaml
@@ -29,6 +29,11 @@ stringData:
   {{- if .Values.maxmindLicenseKey }}
   MAXMIND_LICENSE_KEY: "{{ .Values.maxmindLicenseKey }}"
   {{- end }}
+  {{- if not .Values.config.ui.useDefaults }}
+  {{ if not (quote .Values.config.ui.settings.ldap.bindPassword | empty) }}
+  LDAP_BIND_PASSWORD: "{{ .Values.config.ui.settings.ldap.bindPassword }}"
+  {{ end }}
+  {{- end }}
   DB_CONNECTION_STRING: "{{ $dbConnection }}"
   {{- if eq .Values.fileBackend.type "s3" }}
   S3_ACCESS_KEY_ID: "{{ .Values.fileBackend.s3.accessKeyId | required ".Values.fileBackend.s3.accessKeyId is required." }}"

--- a/charts/pocket-id/tests/configmap_test.yaml
+++ b/charts/pocket-id/tests/configmap_test.yaml
@@ -160,7 +160,6 @@ tests:
         enabled: true
         url: "ldap://example.com"
         bindDN: "cn=admin,dc=example,dc=com"
-        bindPassword: "ldapsecret"
         base: "dc=example,dc=com"
         userSearchFilter: "(uid={0})"
         userGroupSearchFilter: "(member={0})"
@@ -189,7 +188,6 @@ tests:
             LDAP_ENABLED: "true"
             LDAP_URL: "ldap://example.com"
             LDAP_BIND_DN: "cn=admin,dc=example,dc=com"
-            LDAP_BIND_PASSWORD: "ldapsecret"
             LDAP_BASE: "dc=example,dc=com"
             LDAP_USER_SEARCH_FILTER: "(uid={0})"
             LDAP_USER_GROUP_SEARCH_FILTER: "(member={0})"

--- a/charts/pocket-id/tests/secret_test.yaml
+++ b/charts/pocket-id/tests/secret_test.yaml
@@ -173,3 +173,17 @@ tests:
           path: stringData
           content:
             S3_ACCESS_KEY_ID: {}
+
+  - it: Should create Secret with ui values set (ldap)
+    set:
+      encryptionKey: test-encryption-key
+      config.ui.useDefaults: false
+      config.ui.settings.ldap:
+        bindPassword: "ldapsecret"
+    asserts:
+      - isKind:
+          of: Secret
+      - isSubset:
+          path: stringData
+          content:
+            LDAP_BIND_PASSWORD: "ldapsecret"

--- a/e2e/pocket-id/_lib/verify-ldap-sync.step.yaml
+++ b/e2e/pocket-id/_lib/verify-ldap-sync.step.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/steptemplate-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: verify-ldap-sync
+  labels:
+    chart: pocket-id
+spec:
+  try:
+    - apply:
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: test-ldap-sync
+            labels:
+              charts.anza-labs.dev/test: pocket-id-ldap-sync
+          spec:
+            backoffLimit: 0
+            template:
+              metadata:
+                labels:
+                  charts.anza-labs.dev/test: pocket-id-ldap-sync
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.10.1
+                    imagePullPolicy: IfNotPresent
+                    command: ["/bin/sh", "-c"]
+                    args:
+                      - |
+                        set -eu
+
+                        URL="http://${NAMESPACE}-pocket-id.${NAMESPACE}/api/users"
+
+                        for i in $(seq 1 60); do
+                          echo "Attempt ${i}: GET ${URL}"
+                          body="$(curl -sS -f -H "X-API-KEY: ${API_KEY}" "${URL}" || true)"
+                          echo "${body}"
+                          if echo "${body}" | grep -q "\"username\":\"${EXPECTED_USERNAME}\""; then
+                            echo "found ${EXPECTED_USERNAME}"
+                            exit 0
+                          fi
+                          sleep 5
+                        done
+
+                        echo "${EXPECTED_USERNAME} not found in synced users"
+                        exit 1
+                    env:
+                      - name: NAMESPACE
+                        value: ($namespace)
+                      - name: API_KEY
+                        value: ($apiKey)
+                      - name: EXPECTED_USERNAME
+                        value: ($expectedUsername)
+    - assert:
+        timeout: 360s
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: test-ldap-sync
+          status:
+            succeeded: 1
+  catch:
+    - describe:
+        apiVersion: batch/v1
+        kind: Job
+        name: test-ldap-sync
+    - podLogs:
+        namespace: ($namespace)
+        selector: charts.anza-labs.dev/test=pocket-id-ldap-sync
+        tail: -1
+    - podLogs:
+        namespace: ($namespace)
+        selector: app.kubernetes.io/name=pocket-id
+        tail: -1
+    - podLogs:
+        namespace: ($namespace)
+        selector: app.kubernetes.io/name=glauth
+        tail: -1

--- a/e2e/pocket-id/ldap/chainsaw-test.yaml
+++ b/e2e/pocket-id/ldap/chainsaw-test.yaml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: pocket-id-ldap
+  labels:
+    chart: pocket-id
+
+spec:
+  concurrent: true
+  timeouts:
+    cleanup: 60s
+
+  bindings:
+    - name: apiKey
+      value: test-static-api-key-for-e2e
+    - name: ldapUrl
+      value: (join('', ['ldap://', $namespace, '-glauth.', $namespace, ':3893']))
+    - name: glauthArgs
+      value: |
+        --set-json=secret.value.users=[{"name":"serviceuser","mail":"serviceuser@example.com","uidnumber":5003,"primarygroup":5502,"passsha256":"652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0","capabilities":[{"action":"search","object":"*"}]},{"name":"johndoe","mail":"johndoe@example.com","givenname":"John","sn":"Doe","uidnumber":5004,"primarygroup":5503,"passsha256":"652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0"}]
+        --set-json=secret.value.groups=[{"name":"svcaccts","gidnumber":5502},{"name":"users","gidnumber":5503}]
+    - name: pocketIdArgs
+      value: >-
+        (join(' ', [join('', ['--set=staticApiKey=', $apiKey]),
+        '--set=config.ui.useDefaults=false',
+        join('', ['--set=config.ui.settings.ldap.url=', $ldapUrl]),
+        '--set=config.ui.settings.ldap.enabled=true',
+        '--set=config.ui.settings.ldap.bindDN=cn=serviceuser\,ou=svcaccts\,dc=glauth\,dc=com',
+        '--set=config.ui.settings.ldap.bindPassword=mysecret',
+        '--set=config.ui.settings.ldap.base=dc=glauth\,dc=com',
+        '--set=config.ui.settings.ldap.userSearchFilter=(objectClass=posixAccount)',
+        '--set=config.ui.settings.ldap.userGroupSearchFilter=(objectClass=posixGroup)',
+        '--set=config.ui.settings.ldap.attributes.user.uniqueIdentifier=uidNumber',
+        '--set=config.ui.settings.ldap.attributes.user.username=cn',
+        '--set=config.ui.settings.ldap.attributes.user.email=mail',
+        '--set=config.ui.settings.ldap.attributes.user.firstName=givenName',
+        '--set=config.ui.settings.ldap.attributes.user.lastName=sn',
+        '--set=config.ui.settings.ldap.attributes.group.member=memberUid',
+        '--set=config.ui.settings.ldap.attributes.group.uniqueIdentifier=gidNumber',
+        '--set=config.ui.settings.ldap.attributes.group.name=cn']))
+
+  steps:
+    - name: Install glauth
+      use:
+        template: ../../glauth/_lib/helm-install.step.yaml
+        with:
+          bindings:
+            - name: arguments
+              value: ($glauthArgs)
+            - name: namespace
+              value: ($namespace)
+
+    - name: Validate glauth installation
+      use:
+        template: ../../glauth/_lib/validate-core-installation.step.yaml
+        with:
+          bindings:
+            - name: namespace
+              value: ($namespace)
+
+    - name: Install pocket-id
+      use:
+        template: ../_lib/helm-install.step.yaml
+        with:
+          bindings:
+            - name: arguments
+              value: ($pocketIdArgs)
+            - name: namespace
+              value: ($namespace)
+
+    - name: Validate pocket-id installation
+      use:
+        template: ../_lib/validate-core-installation.step.yaml
+        with:
+          bindings:
+            - name: namespace
+              value: ($namespace)
+
+    - name: Verify LDAP user sync
+      use:
+        template: ../_lib/verify-ldap-sync.step.yaml
+        with:
+          bindings:
+            - name: namespace
+              value: ($namespace)
+            - name: apiKey
+              value: ($apiKey)
+            - name: expectedUsername
+              value: johndoe


### PR DESCRIPTION
Install glauth alongside pocket-id, wire pocket-id LDAP env at the
in-cluster glauth service, and assert a seeded user (`johndoe`)
appears via `GET /api/users` using a static API key. Verification job
extracted to `_lib/verify-ldap-sync.step.yaml` so future LDAP-backed
tests can reuse it.

Supporting chart change: move LDAP_BIND_PASSWORD from the ConfigMap
to the Secret. Bind credentials must not be rendered into a
ConfigMap; gated by `config.ui.useDefaults=false` to match the other
LDAP env keys. Helm unit tests updated.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek.98@gmail.com>
